### PR TITLE
Fix to always display keyboard

### DIFF
--- a/Boolder/UI/Map/Search/SearchView.swift
+++ b/Boolder/UI/Map/Search/SearchView.swift
@@ -12,6 +12,7 @@ struct SearchView: View {
     @ObservedObject var mapState: MapState
     @State private var isEditing = false
     @State private var query = ""
+    @FocusState private var isFocused: Bool
 
     var body: some View {
         Group {
@@ -26,6 +27,17 @@ struct SearchView: View {
                   .frame(maxWidth: 400)
                   .padding(10)
                   .padding(.horizontal, 25)
+                  .focused($isFocused)
+                  .background(isEditing ? Color(.imageBackground) : Color(.systemBackground))
+                  .cornerRadius(12)
+                  .shadow(color: Color(.secondaryLabel).opacity(isEditing ? 0 : 0.5), radius: 5)
+                  .simultaneousGesture(TapGesture().onEnded {
+                      mapState.presentProblemDetails = false
+                      withAnimation {
+                          isEditing = true
+                          isFocused = true
+                      }
+                  })
                   .overlay(
                     HStack {
                       Image(systemName: "magnifyingglass")
@@ -46,10 +58,6 @@ struct SearchView: View {
                       }
                     }
                   )
-                  
-                  .background(isEditing ? Color(.imageBackground) : Color(.systemBackground))
-                  .cornerRadius(12)
-                  .shadow(color: Color(.secondaryLabel).opacity(isEditing ? 0 : 0.5), radius: 5)
                     
                   if isEditing {
                       Button(action: {
@@ -67,12 +75,6 @@ struct SearchView: View {
                 .disableAutocorrection(true)
                 .padding(.horizontal)
                 .padding(.top, 8)
-                .simultaneousGesture(TapGesture().onEnded {
-                    mapState.presentProblemDetails = false
-                    withAnimation {
-                        isEditing = true
-                    }
-                })
                 
                 VStack(spacing: 0) {
                     if query.count == 0 {
@@ -160,7 +162,8 @@ struct SearchView: View {
     }
     
     func dismiss() {
-        isEditing = false
+        isEditing =  false
+        isFocused = false
         query = ""
         
         UIApplication.shared.dismissKeyboard()
@@ -169,6 +172,6 @@ struct SearchView: View {
 
 //struct SearchView_Previews: PreviewProvider {
 //    static var previews: some View {
-//        SearchView()
+//        SearchView(mapState: MapState.init())
 //    }
 //}


### PR DESCRIPTION
Fixes #34.

The issue was happened when you tap outside of the red border inside of search box. 
![Simulator Screenshot - iPhone 16 - 2024-10-25 at 09 15 06](https://github.com/user-attachments/assets/a030c1e1-470b-4bc5-baad-4db09fed36d1)


I found `FocusState`[property](https://developer.apple.com/documentation/swiftui/focusstate), and applied. 
Also `.tapGesture` was applied inside of entire textfield HStack, which causes some issues, when user tap "cancel" button. I  moved .tapGesture directly attach to the cancel button.

