### PR TITLE
Add pulse navigation assistance to boulder

### DIFF
--- a/Boolder.xcodeproj/project.pbxproj
+++ b/Boolder.xcodeproj/project.pbxproj
@@ -113,6 +113,8 @@
 		03C104EA290ACC1A007A94D7 /* MapboxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C104E8290ACC1A007A94D7 /* MapboxViewController.swift */; };
 		03C104EC290ACDC6007A94D7 /* MapboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C104EB290ACDC6007A94D7 /* MapboxView.swift */; };
 		03C104ED290ACDC6007A94D7 /* MapboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C104EB290ACDC6007A94D7 /* MapboxView.swift */; };
+		03ABCDE2290ACDC6007A94D7 /* NavigationHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ABCDE1290ACDC6007A94D7 /* NavigationHUD.swift */; };
+		03ABCDE3290ACDC6007A94D7 /* NavigationHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ABCDE1290ACDC6007A94D7 /* NavigationHUD.swift */; };
 		03C104F3290BFBCE007A94D7 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 03C104F2290BFBCE007A94D7 /* SQLite */; };
 		03C104F5290BFBD8007A94D7 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 03C104F4290BFBD8007A94D7 /* SQLite */; };
 		03C104F7290C0688007A94D7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C104F6290C0688007A94D7 /* ContentView.swift */; };
@@ -253,6 +255,7 @@
 		03B9106F2B2C798200DE7B45 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		03C104E8290ACC1A007A94D7 /* MapboxViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxViewController.swift; sourceTree = "<group>"; };
 		03C104EB290ACDC6007A94D7 /* MapboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxView.swift; sourceTree = "<group>"; };
+		03ABCDE1290ACDC6007A94D7 /* NavigationHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationHUD.swift; sourceTree = "<group>"; };
 		03C104F6290C0688007A94D7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		03C104F9290C09B5007A94D7 /* SqliteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqliteStore.swift; sourceTree = "<group>"; };
 		03C5A3602C4F9E750057C42A /* Downloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
@@ -397,6 +400,7 @@
 				031F36AF291CE56100BD0C2B /* MapState.swift */,
 				03C104EB290ACDC6007A94D7 /* MapboxView.swift */,
 				03C104E8290ACC1A007A94D7 /* MapboxViewController.swift */,
+				03ABCDE1290ACDC6007A94D7 /* NavigationHUD.swift */,
 				038F7F432C3A8CC500AE7028 /* Download */,
 				03809ACE2F508F4600ACDC06 /* AllFiltersView.swift */,
 				03DE504427BFA895003E5B2A /* GradeRangePickerView.swift */,
@@ -781,6 +785,7 @@
 				37379924258E619400711EDA /* GradeRange.swift in Sources */,
 				37379926258E619400711EDA /* Grade.swift in Sources */,
 				03C104ED290ACDC6007A94D7 /* MapboxView.swift in Sources */,
+				03ABCDE3290ACDC6007A94D7 /* NavigationHUD.swift in Sources */,
 				033F70DF291959FF000DD3F4 /* TopAreasDryFast.swift in Sources */,
 				03FD89942D8DB18000B7FAD9 /* Bundle+AppVersion.swift in Sources */,
 				037AF0352C538F2700AB9392 /* ClusterViewWithActionsheet.swift in Sources */,
@@ -874,6 +879,7 @@
 				038F7F4A2C3A8CC500AE7028 /* DownloadButtonView.swift in Sources */,
 				37A8C80F245326F200DC161F /* Grade.swift in Sources */,
 				03C104EC290ACDC6007A94D7 /* MapboxView.swift in Sources */,
+				03ABCDE2290ACDC6007A94D7 /* NavigationHUD.swift in Sources */,
 				03C5A3612C4F9E750057C42A /* Downloader.swift in Sources */,
 				031A4C9629673C90002CBF52 /* FlowLayout.swift in Sources */,
 				039A22A6295F21FA0096E137 /* AreaProblemsView.swift in Sources */,

--- a/Boolder/UI/Map/MapContainerView.swift
+++ b/Boolder/UI/Map/MapContainerView.swift
@@ -44,23 +44,34 @@ struct MapContainerView: View {
                 searchButtonOverlay
                     .zIndex(20)
             }
-            
+
+            if mapState.shouldShowNavigationOverlay {
+                NavigationHUD()
+                    .zIndex(25)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
             AreaToolbarView()
                 .frame(maxWidth: 600)
                 .zIndex(30)
                 .opacity(mapState.selectedArea != nil ? 1 : 0)
         }
+        .animation(.easeInOut(duration: 0.25), value: mapState.shouldShowNavigationOverlay)
         .sheet(isPresented: $mapState.presentSearch) {
             SearchSheetView()
         }
         .onChange(of: mapState.presentProblemDetails) { oldValue, newValue in
             if !newValue {
+                let wasNavigating = mapState.shouldShowNavigationOverlay
                 mapState.deselectTopo()
+                if wasNavigating {
+                    mapState.clearProblemSelection()
+                }
             }
         }
         .onChange(of: appState.selectedProblem) { oldValue, newValue in
             if let problem = appState.selectedProblem {
-                mapState.selectAndPresentAndCenterOnProblem(problem)
+                mapState.selectAndPresentAndCenterOnProblem(problem, source: .navigation)
                 mapState.presentAreaView = false
             }
         }
@@ -218,7 +229,7 @@ struct MapContainerView: View {
                         
                         HStack {
                             Button {
-                                mapState.selectAndPresentAndCenterOnProblem(start)
+                                mapState.selectAndPresentAndCenterOnProblem(start, source: .navigation)
                                 mapState.displayCircuitStartButton = false
                             } label: {
                                 HStack {

--- a/Boolder/UI/Map/MapState.swift
+++ b/Boolder/UI/Map/MapState.swift
@@ -112,11 +112,11 @@ class MapState {
     }
     
     
-    func selectAndPresentAndCenterOnProblem (_ problem: Problem) {
+    func selectAndPresentAndCenterOnProblem (_ problem: Problem, source: Selection.Source = .other) {
         centerOnProblem(problem)
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [self] in
-            self.selectProblem(problem)
+            self.selectProblem(problem, source: source)
             self.presentProblemDetails = true
         }
     }
@@ -201,6 +201,8 @@ class MapState {
             case circleView
             case line
             case map
+            case search
+            case navigation
             case other
         }
     }
@@ -267,6 +269,32 @@ class MapState {
     /// The id of the actively selected problem (0 when in topo mode or none).
     /// Stable during topo-to-topo swipes; only changes on problem-to-problem taps.
     private(set) var activeProblemId: Int = 0
+
+    /// User's last known coordinate (forwarded from the Mapbox location stream).
+    /// Drives the dotted line and the navigation HUD. `nil` until the first fix
+    /// arrives or when the user has denied location access.
+    private(set) var userCoordinate: CLLocationCoordinate2D?
+
+    func updateUserCoordinate(_ coordinate: CLLocationCoordinate2D?) {
+        userCoordinate = coordinate
+    }
+
+    func clearProblemSelection() {
+        selection = .none
+    }
+
+    /// `true` when the user reached the current selection through a navigation
+    /// flow (search, discover, deep link, circuit start) — i.e. we should
+    /// guide them to the boulder with a halo + dotted line + HUD. Hidden in
+    /// topo mode and for direct map/circle taps where the user is already
+    /// looking at the boulder.
+    var shouldShowNavigationOverlay: Bool {
+        guard !isInTopoMode, selectedProblem != nil else { return false }
+        switch currentSelectionSource {
+        case .search, .navigation: return true
+        case .map, .line, .circleView, .other: return false
+        }
+    }
     
     // MARK: - Cached boulder data (only refreshed when boulder changes)
     

--- a/Boolder/UI/Map/MapboxView.swift
+++ b/Boolder/UI/Map/MapboxView.swift
@@ -47,6 +47,21 @@ struct MapboxView: UIViewControllerRepresentable {
                 vc.setProblemAsSelected(problemFeatureId: String(selectedId))
             }
         }
+
+        // Pulse halo + dotted line: only show when the selection came from a
+        // navigation flow (search, discover, deep link, circuit start).
+        let shouldShowNav = mapState.shouldShowNavigationOverlay
+        let navTargetId = shouldShowNav ? (mapState.selectedProblem?.id ?? 0) : 0
+        if context.coordinator.lastNavTargetProblemId != navTargetId {
+            context.coordinator.lastNavTargetProblemId = navTargetId
+            if navTargetId != 0, let coord = mapState.selectedProblem?.coordinate {
+                vc.showSelectedProblemPulse(at: coord)
+                vc.showUserToProblemLine(target: coord)
+            } else {
+                vc.hideSelectedProblemPulse()
+                vc.hideUserToProblemLine()
+            }
+        }
         
         // Handle centerOnProblem changes
         if let centerOnProblem = mapState.centerOnProblem {
@@ -134,6 +149,7 @@ struct MapboxView: UIViewControllerRepresentable {
         var lastRefreshFiltersCount: Int = 0
         var lastIsTopoMode: Bool = false
         var lastCenterOnBoulderCount: Int = 0
+        var lastNavTargetProblemId: Int = 0
 
         init(_ parent: MapboxView) {
             self.parent = parent
@@ -181,6 +197,10 @@ struct MapboxView: UIViewControllerRepresentable {
             parent.mapState.presentProblemDetails = false
         }
         
+        func locationDidChange(coordinate: CLLocationCoordinate2D?) {
+            parent.mapState.updateUserCoordinate(coordinate)
+        }
+
         func cameraChanged(state: MapboxMaps.CameraState) {
             if parent.mapState.displayCircuitStartButton {
                 parent.mapState.displayCircuitStartButton = false

--- a/Boolder/UI/Map/MapboxViewController.swift
+++ b/Boolder/UI/Map/MapboxViewController.swift
@@ -71,12 +71,27 @@ class MapboxViewController: UIViewController {
             guard let self = self else { return }
             self.addSources()
             self.addLayers()
+            self.addNavigationOverlaySourcesAndLayers()
             if let filters = self.currentFilters {
                 self.applyFilters(filters)
             }
             if let circuit = self.currentCircuit {
                 self.setCircuitAsSelected(circuit: circuit)
             }
+            // Restore the pulse/line for whatever was selected before the reload.
+            if let coord = self.pulseCoordinate {
+                self.showSelectedProblemPulse(at: coord)
+            }
+            if self.lineTargetCoordinate != nil {
+                self.refreshUserToProblemLine()
+            }
+        }.store(in: &cancelables)
+
+        mapView.location.onLocationChange.observe { [weak self] locations in
+            guard let self = self, let coord = locations.last?.coordinate else { return }
+            self.lastUserCoordinate = coord
+            self.refreshUserToProblemLine()
+            self.delegate?.locationDidChange(coordinate: coord)
         }.store(in: &cancelables)
         
         registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: MapboxViewController, _) in
@@ -1091,6 +1106,172 @@ class MapboxViewController: UIViewController {
         
         return withDistances.sorted { $0.1 < $1.1 }.map { $0.0.queriedFeature.feature }
     }
+
+    // MARK: - Selected-problem navigation overlay (pulse halo + dotted line)
+
+    private let pulseSourceId = "selected-problem-pulse"
+    private let pulseInnerLayerId = "selected-problem-pulse-inner"
+    private let pulseOuterLayerId = "selected-problem-pulse-outer"
+    private let userToProblemSourceId = "user-to-problem-line"
+    private let userToProblemLayerId = "user-to-problem-line"
+
+    private var pulseDisplayLink: CADisplayLink?
+    private var pulseStartTime: CFTimeInterval = 0
+    private var pulseCoordinate: CLLocationCoordinate2D?
+
+    private var lastUserCoordinate: CLLocationCoordinate2D?
+    private(set) var lineTargetCoordinate: CLLocationCoordinate2D?
+
+    private func addNavigationOverlaySourcesAndLayers() {
+        do {
+            var pulse = GeoJSONSource(id: pulseSourceId)
+            pulse.data = .empty
+            try mapView.mapboxMap.addSource(pulse)
+
+            var outer = CircleLayer(id: pulseOuterLayerId, source: pulseSourceId)
+            outer.circleColor = .constant(StyleColor(UIColor(resource: .appGreen)))
+            outer.circleRadius = .constant(0)
+            outer.circleOpacity = .constant(0)
+            outer.circleEmissiveStrength = .constant(1.0)
+            outer.circlePitchAlignment = .constant(.map)
+            outer.visibility = .constant(.none)
+
+            var inner = CircleLayer(id: pulseInnerLayerId, source: pulseSourceId)
+            inner.circleColor = .constant(StyleColor(UIColor(resource: .appGreen)))
+            inner.circleRadius = .constant(0)
+            inner.circleOpacity = .constant(0)
+            inner.circleEmissiveStrength = .constant(1.0)
+            inner.circlePitchAlignment = .constant(.map)
+            inner.visibility = .constant(.none)
+
+            try mapView.mapboxMap.addLayer(outer, layerPosition: .above("problems"))
+            try mapView.mapboxMap.addLayer(inner, layerPosition: .above(pulseOuterLayerId))
+
+            var line = GeoJSONSource(id: userToProblemSourceId)
+            line.data = .empty
+            try mapView.mapboxMap.addSource(line)
+
+            var lineLayer = LineLayer(id: userToProblemLayerId, source: userToProblemSourceId)
+            lineLayer.lineColor = .constant(StyleColor(UIColor(resource: .appGreen)))
+            lineLayer.lineWidth = .constant(3)
+            lineLayer.lineDasharray = .constant([1.5, 2.0])
+            lineLayer.lineCap = .constant(.round)
+            lineLayer.lineJoin = .constant(.round)
+            lineLayer.lineEmissiveStrength = .constant(0.9)
+            lineLayer.lineOpacity = .constant(0.9)
+            lineLayer.visibility = .constant(.none)
+
+            try mapView.mapboxMap.addLayer(lineLayer, layerPosition: .below("problems"))
+        } catch {
+            print("Ran into an error adding the navigation overlay layers: \(error)")
+        }
+    }
+
+    func showSelectedProblemPulse(at coordinate: CLLocationCoordinate2D) {
+        pulseCoordinate = coordinate
+        let feature = Feature(geometry: .point(Point(coordinate)))
+        try? mapView.mapboxMap.updateGeoJSONSource(
+            withId: pulseSourceId,
+            geoJSON: .feature(feature)
+        )
+        setCircleLayerVisibility(pulseInnerLayerId, .visible)
+        setCircleLayerVisibility(pulseOuterLayerId, .visible)
+        startPulseDisplayLink()
+    }
+
+    func hideSelectedProblemPulse() {
+        pulseCoordinate = nil
+        stopPulseDisplayLink()
+        setCircleLayerVisibility(pulseInnerLayerId, .none)
+        setCircleLayerVisibility(pulseOuterLayerId, .none)
+    }
+
+    func showUserToProblemLine(target: CLLocationCoordinate2D) {
+        lineTargetCoordinate = target
+        refreshUserToProblemLine()
+    }
+
+    func hideUserToProblemLine() {
+        lineTargetCoordinate = nil
+        try? mapView.mapboxMap.updateLayer(withId: userToProblemLayerId, type: LineLayer.self) { layer in
+            layer.visibility = .constant(.none)
+        }
+    }
+
+    private func refreshUserToProblemLine() {
+        guard let target = lineTargetCoordinate,
+              let user = lastUserCoordinate ?? mapView.location.latestLocation?.coordinate else {
+            try? mapView.mapboxMap.updateLayer(withId: userToProblemLayerId, type: LineLayer.self) { layer in
+                layer.visibility = .constant(.none)
+            }
+            return
+        }
+        let line = LineString([user, target])
+        let feature = Feature(geometry: .lineString(line))
+        try? mapView.mapboxMap.updateGeoJSONSource(
+            withId: userToProblemSourceId,
+            geoJSON: .feature(feature)
+        )
+        try? mapView.mapboxMap.updateLayer(withId: userToProblemLayerId, type: LineLayer.self) { layer in
+            layer.visibility = .constant(.visible)
+        }
+    }
+
+    private func startPulseDisplayLink() {
+        stopPulseDisplayLink()
+        pulseStartTime = CACurrentMediaTime()
+        let link = CADisplayLink(target: self, selector: #selector(pulseTick))
+        link.preferredFramesPerSecond = 30
+        link.add(to: .main, forMode: .common)
+        pulseDisplayLink = link
+    }
+
+    private func stopPulseDisplayLink() {
+        pulseDisplayLink?.invalidate()
+        pulseDisplayLink = nil
+    }
+
+    @objc private func pulseTick() {
+        let period: CFTimeInterval = 1.6
+        let elapsed = CACurrentMediaTime() - pulseStartTime
+        let tInner = elapsed.truncatingRemainder(dividingBy: period) / period
+        let tOuter = (elapsed + period / 2).truncatingRemainder(dividingBy: period) / period
+
+        let innerR = 12.0 + 24.0 * tInner
+        let innerA = 0.85 * (1.0 - tInner)
+        let outerR = 24.0 + 36.0 * tOuter
+        let outerA = 0.55 * (1.0 - tOuter)
+
+        try? mapView.mapboxMap.updateLayer(withId: pulseInnerLayerId, type: CircleLayer.self) { l in
+            l.circleRadius = .constant(innerR)
+            l.circleOpacity = .constant(innerA)
+        }
+        try? mapView.mapboxMap.updateLayer(withId: pulseOuterLayerId, type: CircleLayer.self) { l in
+            l.circleRadius = .constant(outerR)
+            l.circleOpacity = .constant(outerA)
+        }
+    }
+
+    private func setCircleLayerVisibility(_ id: String, _ visibility: Visibility) {
+        try? mapView.mapboxMap.updateLayer(withId: id, type: CircleLayer.self) { layer in
+            layer.visibility = .constant(visibility)
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if pulseCoordinate != nil { startPulseDisplayLink() }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        stopPulseDisplayLink()
+    }
+
+    deinit {
+        pulseDisplayLink?.invalidate()
+        pulseDisplayLink = nil
+    }
 }
 
 import CoreLocation
@@ -1105,4 +1286,5 @@ protocol MapBoxViewDelegate {
     func unselectCircuit()
     func cameraChanged(state: CameraState)
     func dismissProblemDetails()
+    func locationDidChange(coordinate: CLLocationCoordinate2D?)
 }

--- a/Boolder/UI/Map/NavigationHUD.swift
+++ b/Boolder/UI/Map/NavigationHUD.swift
@@ -1,0 +1,74 @@
+//
+//  NavigationHUD.swift
+//  Boolder
+//
+//  Created by Nicolas Mondollot on 07/05/2026.
+//  Copyright © 2026 Nicolas Mondollot. All rights reserved.
+//
+
+import SwiftUI
+import CoreLocation
+
+struct NavigationHUD: View {
+    @Environment(MapState.self) private var mapState: MapState
+
+    var body: some View {
+        VStack {
+            if let user = mapState.userCoordinate,
+               let target = mapState.selectedProblem?.coordinate {
+                let bearing = Self.bearingDegrees(from: user, to: target)
+                let distance = CLLocation(latitude: user.latitude, longitude: user.longitude)
+                    .distance(from: CLLocation(latitude: target.latitude, longitude: target.longitude))
+
+                HStack(spacing: 8) {
+                    Image(systemName: "arrow.up")
+                        .rotationEffect(.degrees(bearing))
+                        .font(.subheadline.weight(.semibold))
+                    Text("\(Self.formattedDistance(distance)) · \(Self.cardinal8(forDegrees: bearing))")
+                        .font(.subheadline.weight(.medium))
+                }
+                .foregroundColor(.primary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(.ultraThinMaterial, in: Capsule())
+                .shadow(color: Color.black.opacity(0.15), radius: 4, y: 2)
+                .padding(.top, 64)
+            }
+            Spacer()
+        }
+        .allowsHitTesting(false)
+    }
+
+    private static func formattedDistance(_ meters: CLLocationDistance) -> String {
+        let measurement = Measurement(value: meters, unit: UnitLength.meters)
+        let formatter = MeasurementFormatter()
+        formatter.unitOptions = .naturalScale
+        formatter.unitStyle = .medium
+        formatter.numberFormatter.maximumFractionDigits = meters < 1000 ? 0 : 1
+        return formatter.string(from: measurement)
+    }
+
+    /// Forward azimuth (great-circle) from a → b, in degrees [0, 360).
+    private static func bearingDegrees(
+        from a: CLLocationCoordinate2D,
+        to b: CLLocationCoordinate2D
+    ) -> Double {
+        let lat1 = a.latitude * .pi / 180
+        let lat2 = b.latitude * .pi / 180
+        let dLon = (b.longitude - a.longitude) * .pi / 180
+        let y = sin(dLon) * cos(lat2)
+        let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+        var deg = atan2(y, x) * 180 / .pi
+        if deg < 0 { deg += 360 }
+        return deg
+    }
+
+    private static func cardinal8(forDegrees deg: Double) -> String {
+        let keys = [
+            "map.cardinal.n", "map.cardinal.ne", "map.cardinal.e", "map.cardinal.se",
+            "map.cardinal.s", "map.cardinal.sw", "map.cardinal.w", "map.cardinal.nw"
+        ]
+        let idx = Int((deg + 22.5) / 45) % 8
+        return NSLocalizedString(keys[idx], comment: "Cardinal direction abbreviation")
+    }
+}

--- a/Boolder/UI/Map/Problem details/Topo/TopoView.swift
+++ b/Boolder/UI/Map/Problem details/Topo/TopoView.swift
@@ -515,7 +515,7 @@ struct TopoView: View {
         switch mapState.currentSelectionSource {
         case .circleView, .map:
             bounceAnimation.toggle()
-        case .line, .other:
+        case .line, .other, .search, .navigation:
             break
         }
     }

--- a/Boolder/UI/Map/Search/SearchSheetView.swift
+++ b/Boolder/UI/Map/Search/SearchSheetView.swift
@@ -132,6 +132,6 @@ struct SearchSheetView: View {
         dismiss()
         mapState.clearFilters()
         mapState.unselectCircuit()
-        mapState.selectAndPresentAndCenterOnProblem(problem)
+        mapState.selectAndPresentAndCenterOnProblem(problem, source: .search)
     }
 }

--- a/Boolder/en.lproj/Localizable.strings
+++ b/Boolder/en.lproj/Localizable.strings
@@ -213,3 +213,13 @@
 // MARK: Boulder
 "boulder.info_basic" = "%d problems";
 "boulder.info_basic_singular" = "%d problem";
+
+// MARK: Map cardinal directions (HUD abbreviations)
+"map.cardinal.n" = "N";
+"map.cardinal.ne" = "NE";
+"map.cardinal.e" = "E";
+"map.cardinal.se" = "SE";
+"map.cardinal.s" = "S";
+"map.cardinal.sw" = "SW";
+"map.cardinal.w" = "W";
+"map.cardinal.nw" = "NW";

--- a/Boolder/fr.lproj/Localizable.strings
+++ b/Boolder/fr.lproj/Localizable.strings
@@ -212,3 +212,13 @@
 // MARK: Boulder
 "boulder.info_basic" = "%d voies";
 "boulder.info_basic_singular" = "%d voie";
+
+// MARK: Map cardinal directions (HUD abbreviations)
+"map.cardinal.n" = "N";
+"map.cardinal.ne" = "NE";
+"map.cardinal.e" = "E";
+"map.cardinal.se" = "SE";
+"map.cardinal.s" = "S";
+"map.cardinal.sw" = "SO";
+"map.cardinal.w" = "O";
+"map.cardinal.nw" = "NO";


### PR DESCRIPTION
When a user searched for a problem and selected it, the map only added a thin green stroke around the matching circle which is barely visible at typical zoom and unhelpful for actually walking to the boulder.

This PR adds three coordinated visuals that turn on for navigation-flow selections (search, discover, deep links, circuit start) and stay off for direct map / circle taps hopefully helping users find boulders more conviniently:

- **Pulsing halo at the selected boulder.** Two `CircleLayer`s (inner + outer phase-shifted by half a cycle) backed by a `GeoJSONSource`, animated by a `CADisplayLink` at 30 fps. Constant pixel-space radius (no `minZoom`), so the halo is visible from world view, not only at zoom ≥ 15 like the existing problems layer.
- **Dotted green line** from the user's location to the boulder.`GeoJSONSource` + `LineLayer` with `lineDasharray = [1.5, 2.0]`, inserted *below* the `problems` layer so it slides under pin circles. Subscribes to Mapbox`mapView.location.onLocationChange` and hides itself when there is no fix.
- **Direction HUD pill** at the top of the screen — `"320 m · NW"` with an arrow icon rotated to bearing. Distance via `MeasurementFormatter` with`.naturalScale` so units follow the user's locale; bearing via the standard great-circle forward-azimuth formula bucketed into 8 cardinal points.